### PR TITLE
Accept, cancel, or apply pull request changes

### DIFF
--- a/lib/models/pull-request.js
+++ b/lib/models/pull-request.js
@@ -94,7 +94,7 @@ export default class PullRequest {
       this.github.updatePullRequest(this.baseFork, this.number, attrs, (err, nattrs) => {
         if (err) return callback(err);
 
-        this._applyAttrs(attrs);
+        this._applyAttrs(nattrs);
         callback(null);
       });
     };

--- a/lib/models/pull-request.js
+++ b/lib/models/pull-request.js
@@ -123,6 +123,10 @@ export default class PullRequest {
     } else {
       this.state = nState;
     }
+
+    if (attrs.meta && attrs.meta.etag) {
+      this.etag = attrs.meta.etag;
+    }
   }
 
   toString() {

--- a/lib/models/pull-request.js
+++ b/lib/models/pull-request.js
@@ -45,6 +45,7 @@ export default class PullRequest {
     this.number = null;
     this.title = "";
     this.body = "";
+    this.etag = null;
 
     this.repository = repo;
     this.github = this.repository.transport.github;
@@ -64,7 +65,7 @@ export default class PullRequest {
     let noop = () => callback(null);
 
     let update = () => {
-      this.github.getPullRequest(this.baseFork, this.number, (err, attrs) => {
+      this.github.getPullRequest(this.baseFork, this.number, this.etag, (err, attrs) => {
         if (err) return callback(err);
 
         this._applyAttrs(attrs);
@@ -91,7 +92,7 @@ export default class PullRequest {
     };
 
     let useTransport = () => {
-      this.github.updatePullRequest(this.baseFork, this.number, attrs, (err, nattrs) => {
+      this.github.updatePullRequest(this.baseFork, this.number, attrs, this.etag, (err, nattrs) => {
         if (err) return callback(err);
 
         this._applyAttrs(nattrs);

--- a/lib/models/pull-request.js
+++ b/lib/models/pull-request.js
@@ -88,8 +88,16 @@ export default class PullRequest {
     //
   }
 
-  update(callback) {
-    //
+  update(attrs, callback) {
+    let applyDirectly = () => {
+      this.title = attrs.title;
+      this.body = attrs.body;
+      callback(null);
+    };
+
+    this.state.when({
+      draft: applyDirectly
+    });
   }
 
   close(callback) {

--- a/lib/models/pull-request.js
+++ b/lib/models/pull-request.js
@@ -95,8 +95,17 @@ export default class PullRequest {
       callback(null);
     };
 
+    let useTransport = () => {
+      this.github.updatePullRequest(this.baseFork, this.number, attrs, (err) => {
+        if (err) return callback(err);
+
+        this.refresh(callback);
+      });
+    };
+
     this.state.when({
-      draft: applyDirectly
+      draft: applyDirectly,
+      default: useTransport
     });
   }
 

--- a/lib/models/pull-request.js
+++ b/lib/models/pull-request.js
@@ -16,6 +16,10 @@ class PullRequestState {
     return chosen();
   }
 
+  apiString() {
+    return this.name.toLowerCase();
+  }
+
   toString() {
     return `<State: ${this.name}>`;
   }
@@ -60,19 +64,10 @@ export default class PullRequest {
     let noop = () => callback(null);
 
     let update = () => {
-      this.github.getPullRequest(this.baseFork, this.number, (err, data) => {
+      this.github.getPullRequest(this.baseFork, this.number, (err, attrs) => {
         if (err) return callback(err);
 
-        this.title = data.title;
-        this.body = data.body;
-
-        let nState = stateNames[data.state];
-        if (!nState) {
-          console.error(`Unrecognized pull request state from API: ${nState}`);
-        } else {
-          this.state = nState;
-        }
-
+        this._applyAttrs(attrs);
         callback(null);
       });
     }
@@ -96,10 +91,11 @@ export default class PullRequest {
     };
 
     let useTransport = () => {
-      this.github.updatePullRequest(this.baseFork, this.number, attrs, (err) => {
+      this.github.updatePullRequest(this.baseFork, this.number, attrs, (err, nattrs) => {
         if (err) return callback(err);
 
-        this.refresh(callback);
+        this._applyAttrs(attrs);
+        callback(null);
       });
     };
 
@@ -115,6 +111,18 @@ export default class PullRequest {
 
   merge(callback) {
     //
+  }
+
+  _applyAttrs(attrs) {
+    this.title = attrs.title;
+    this.body = attrs.body;
+
+    let nState = stateNames[attrs.state];
+    if (!nState) {
+      console.error(`Unrecognized pull request state from API: ${nState}`);
+    } else {
+      this.state = nState;
+    }
   }
 
   toString() {

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -79,6 +79,8 @@ export default class Repository {
             sourceFork, first.base.ref,
             currentFork, results.currentBranch
           );
+
+          existing.number = first.number;
           existing.state = State.OPEN;
           existing.title = first.title;
           existing.body = first.body;

--- a/lib/models/repository.js
+++ b/lib/models/repository.js
@@ -85,6 +85,10 @@ export default class Repository {
           existing.title = first.title;
           existing.body = first.body;
 
+          if (response.meta && response.meta.etag) {
+            existing.etag = response.meta.etag;
+          }
+
           callback(null, existing);
         } else {
           let draft = new PullRequest(

--- a/lib/transport/demo/github.js
+++ b/lib/transport/demo/github.js
@@ -18,6 +18,7 @@ module.exports = {
       number: 123,
       title: "the title",
       body: "the body",
+      state: "open",
       base: {
         ref: "base-ref",
         repo: {
@@ -32,11 +33,11 @@ module.exports = {
     callback(null, {current: this.currentFork, source: this.sourceFork});
   },
 
-  getPullRequest: function (fork, id, callback) {
+  getPullRequest: function (fork, number, callback) {
     let chosen;
 
     sourcePullRequests.forEach((each) => {
-      if (each.number === id) {
+      if (each.number === number) {
         chosen = each;
       }
     });
@@ -54,6 +55,18 @@ module.exports = {
       current: [],
       another: []
     }, callback);
+  },
+
+  updatePullRequest: function (fork, number, attrs, callback) {
+    this.getPullRequest(fork, number, (err, pr) => {
+      if (err) return callback(err);
+
+      pr.title = attrs.title;
+      pr.body = attrs.body;
+      pr.state = attrs.state;
+
+      callback(null, pr);
+    });
   },
 
   _forkSwitch: function (forkName, options, callback) {

--- a/lib/transport/demo/github.js
+++ b/lib/transport/demo/github.js
@@ -33,7 +33,7 @@ module.exports = {
     callback(null, {current: this.currentFork, source: this.sourceFork});
   },
 
-  getPullRequest: function (fork, number, callback) {
+  getPullRequest: function (fork, number, etag, callback) {
     let chosen;
 
     sourcePullRequests.forEach((each) => {
@@ -57,7 +57,7 @@ module.exports = {
     }, callback);
   },
 
-  updatePullRequest: function (fork, number, attrs, callback) {
+  updatePullRequest: function (fork, number, attrs, etag, callback) {
     this.getPullRequest(fork, number, (err, pr) => {
       if (err) return callback(err);
 

--- a/lib/transport/demo/github.js
+++ b/lib/transport/demo/github.js
@@ -61,9 +61,9 @@ module.exports = {
     this.getPullRequest(fork, number, (err, pr) => {
       if (err) return callback(err);
 
-      pr.title = attrs.title;
-      pr.body = attrs.body;
-      pr.state = attrs.state;
+      pr.title = attrs.title || pr.title;
+      pr.body = attrs.body || pr.body;
+      pr.state = attrs.state || pr.state;
 
       callback(null, pr);
     });

--- a/lib/transport/live/github.js
+++ b/lib/transport/live/github.js
@@ -24,11 +24,11 @@ module.exports = {
     });
   },
 
-  getPullRequest: function (fork, id, callback) {
+  getPullRequest: function (fork, number, callback) {
     let q = {
       user: fork.user,
       repo: fork.repo,
-      number: id
+      number: number
     };
 
     github.pullRequests.get(q, callback);
@@ -39,5 +39,18 @@ module.exports = {
     query.repo = fork.repo;
 
     github.pullRequests.getAll(query, callback);
-  }
+  },
+
+  updatePullRequest: function (fork, number, attrs, callback) {
+    let m = {
+      user: fork.user,
+      repo: fork.repo,
+      number: number,
+      title: attrs.title,
+      body: attrs.body,
+      state: attrs.state
+    };
+
+    github.pullRequests.update(m, callback);
+  },
 };

--- a/lib/transport/live/github.js
+++ b/lib/transport/live/github.js
@@ -1,7 +1,7 @@
 "use babel";
 
 import async from "async";
-import GitHubClient from "node-github";
+import GitHubClient from "github";
 import package from "../../../package.json";
 
 var github = new GitHubClient({

--- a/lib/transport/live/github.js
+++ b/lib/transport/live/github.js
@@ -24,12 +24,17 @@ module.exports = {
     });
   },
 
-  getPullRequest: function (fork, number, callback) {
+  getPullRequest: function (fork, number, etag, callback) {
     let q = {
       user: fork.user,
       repo: fork.repo,
       number: number
     };
+
+    if (etag) {
+      q.headers = {};
+      q.headers['If-None-Match'] = etag;
+    }
 
     github.pullRequests.get(q, callback);
   },
@@ -41,7 +46,7 @@ module.exports = {
     github.pullRequests.getAll(query, callback);
   },
 
-  updatePullRequest: function (fork, number, attrs, callback) {
+  updatePullRequest: function (fork, number, attrs, etag, callback) {
     let m = {
       user: fork.user,
       repo: fork.repo,
@@ -50,6 +55,11 @@ module.exports = {
       body: attrs.body,
       state: attrs.state
     };
+
+    if (etag) {
+      q.headers = {};
+      q.headers['If-None-Match'] = etag;
+    }
 
     github.pullRequests.update(m, callback);
   },

--- a/lib/views/discussion-component.js
+++ b/lib/views/discussion-component.js
@@ -45,12 +45,13 @@ export default class DiscussionComponent {
 
   render() {
     let elementFunc = this.mode === Mode.VIEW ? this.viewElements.bind(this) : this.editElements.bind(this);
-    let {title, body} = elementFunc();
+    let {title, body, controls} = elementFunc();
 
     return (
       <div className="discussion">
         <div className="block">{title}</div>
         <div className="block">{body}</div>
+        {controls}
       </div>
     )
   }
@@ -66,6 +67,12 @@ export default class DiscussionComponent {
         <atom-text-editor className="body" ref="bodyEditor">
           {this.pullRequest.body}
         </atom-text-editor>
+      ),
+      controls: (
+        <div className="controls padded pull-right">
+          <button className="btn icon icon-circle-slash inline-block-tight" ref="cancelButton">Cancel</button>
+          <button className="btn btn-success icon icon-check inline-block-tight" ref="acceptButton">Accept</button>
+        </div>
       )
     };
   }
@@ -77,7 +84,8 @@ export default class DiscussionComponent {
       ),
       body: (
         <p className="body">{this.pullRequest.body}</p>
-      )
+      ),
+      controls: null
     }
   }
 

--- a/lib/views/discussion-component.js
+++ b/lib/views/discussion-component.js
@@ -47,6 +47,7 @@ export default class DiscussionComponent {
     let attrs = {
       body: this.bodyBuffer,
       title: this.titleBuffer,
+      state: this.pullRequest.state.apiString()
     };
 
     this.pullRequest.update(attrs, (err) => {

--- a/lib/views/discussion-component.js
+++ b/lib/views/discussion-component.js
@@ -61,6 +61,10 @@ export default class DiscussionComponent {
   }
 
   handleCancel() {
+    this.titleBuffer = this.pullRequest.title;
+    this.bodyBuffer = this.pullRequest.body;
+    this.mode = Mode.VIEW;
+
     etch.updateElement(this);
   }
 

--- a/lib/views/discussion-component.js
+++ b/lib/views/discussion-component.js
@@ -44,7 +44,20 @@ export default class DiscussionComponent {
   }
 
   handleAccept() {
-    etch.updateElement(this);
+    let attrs = {
+      body: this.bodyBuffer,
+      title: this.titleBuffer,
+    };
+
+    this.pullRequest.update(attrs, (err) => {
+      if (err) {
+        console.error(err);
+        return;
+      }
+
+      this.mode = Mode.VIEW;
+      etch.updateElement(this);
+    });
   }
 
   handleCancel() {

--- a/lib/views/discussion-component.js
+++ b/lib/views/discussion-component.js
@@ -43,6 +43,14 @@ export default class DiscussionComponent {
     }));
   }
 
+  handleAccept() {
+    etch.updateElement(this);
+  }
+
+  handleCancel() {
+    etch.updateElement(this);
+  }
+
   render() {
     let elementFunc = this.mode === Mode.VIEW ? this.viewElements.bind(this) : this.editElements.bind(this);
     let {title, body, controls} = elementFunc();

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "async": "^1.4.2",
+    "async": "1.4.2",
     "etch": "0.0.7",
-    "node-github": "0.0.3",
-    "nodegit": "^0.4.1"
+    "github": "0.2.4",
+    "nodegit": "0.4.1"
   }
 }

--- a/spec/models/pull-request-spec.js
+++ b/spec/models/pull-request-spec.js
@@ -45,7 +45,8 @@ describe("PullRequest", () => {
             hook(fork, id);
             callback(null, {
               title: "refreshed title",
-              body: "refreshed body"
+              body: "refreshed body",
+              state: "open"
             });
           }
         }
@@ -118,6 +119,9 @@ describe("PullRequest", () => {
         github: {
           updatePullRequest: (fork, number, attrs, callback) => {
             hook(fork, number, attrs);
+
+            attrs.state = attrs.state || "open";
+
             callback(null, attrs);
           }
         }

--- a/spec/models/pull-request-spec.js
+++ b/spec/models/pull-request-spec.js
@@ -113,19 +113,12 @@ describe("PullRequest", () => {
     let repository, t, pr, hook;
 
     beforeEach(() => {
-      let lastAttrs = {};
-
       hook = () => {};
       t = demoTransport.make({
         github: {
-          getPullRequest: (fork, number, callback) => {
-            callback(null, lastAttrs);
-          },
-
           updatePullRequest: (fork, number, attrs, callback) => {
-            lastAttrs = attrs;
             hook(fork, number, attrs);
-            callback(null);
+            callback(null, attrs);
           }
         }
       });

--- a/spec/models/pull-request-spec.js
+++ b/spec/models/pull-request-spec.js
@@ -157,6 +157,40 @@ describe("PullRequest", () => {
       expect(hookCalled).toBe(false);
     });
 
+    let usesTheTransport = (state) => () => {
+      pr.number = 543;
+      pr.state = state;
+
+      let hookParams = null;
+      let cbCalled = false;
+      hook = (fork, number, attrs) => {
+        hookParams = {fork, number, attrs};
+      };
+
+      pr.update({
+        body: "updated body",
+        title: "updated title"
+      }, (err) => {
+        expect(err).toBe(null);
+        cbCalled = true;
+      })
+
+      waitsFor(() => cbCalled);
+
+      runs(() => {
+        expect(hookParams.number).toBe(543);
+        expect(hookParams.attrs.body).toBe("updated body");
+        expect(hookParams.attrs.title).toBe("updated title");
+
+        expect(pr.body).toBe("updated body");
+        expect(pr.title).toBe("updated title");
+      });
+    };
+
+    it("uses the transport for open PRs", usesTheTransport(State.OPEN));
+    it("uses the transport for closed PRs", usesTheTransport(State.CLOSED));
+    it("uses the transport for merged PRs", usesTheTransport(State.MERGED));
+
   });
 
 });

--- a/spec/models/pull-request-spec.js
+++ b/spec/models/pull-request-spec.js
@@ -41,7 +41,7 @@ describe("PullRequest", () => {
       hook = () => {};
       t = demoTransport.make({
         github: {
-          getPullRequest: (fork, id, callback) => {
+          getPullRequest: (fork, id, etag, callback) => {
             hook(fork, id);
             callback(null, {
               title: "refreshed title",
@@ -117,7 +117,7 @@ describe("PullRequest", () => {
       hook = () => {};
       t = demoTransport.make({
         github: {
-          updatePullRequest: (fork, number, attrs, callback) => {
+          updatePullRequest: (fork, number, attrs, etag, callback) => {
             hook(fork, number, attrs);
 
             attrs.state = attrs.state || "open";

--- a/spec/models/pull-request-spec.js
+++ b/spec/models/pull-request-spec.js
@@ -170,7 +170,7 @@ describe("PullRequest", () => {
       }, (err) => {
         expect(err).toBe(null);
         cbCalled = true;
-      })
+      });
 
       waitsFor(() => cbCalled);
 

--- a/spec/views/discussion-component-spec.js
+++ b/spec/views/discussion-component-spec.js
@@ -80,6 +80,14 @@ describe("DiscussionComponent", () => {
       expect(descEditor.getText()).toBe("This is its body");
     });
 
+    it("shows accept and cancel buttons", () => {
+      let acceptButton = element.querySelector("button.btn-success");
+      expect(acceptButton).not.toBe(null);
+
+      let cancelButton = element.querySelector("button.icon-circle-slash");
+      expect(cancelButton).not.toBe(null);
+    });
+
     it("updates the buffered title", () => {
       let titleEditor = element.querySelector("atom-text-editor.title").getModel();
       titleEditor.setText("This is a new title");

--- a/spec/views/discussion-component-spec.js
+++ b/spec/views/discussion-component-spec.js
@@ -1,5 +1,7 @@
 "use babel";
 
+import {getScheduler} from 'etch';
+
 import DiscussionComponent from '../../lib/views/discussion-component';
 import PullRequest, {State} from '../../lib/models/pull-request';
 import Repository from '../../lib/models/repository';
@@ -103,6 +105,21 @@ describe("DiscussionComponent", () => {
       expect(component.bodyBuffer).toBe("This is a new body");
       expect(pullRequest.body).toBe("This is its body");
     });
+
+    it("applies changes on accept", () => {
+      component.refs.bodyEditor.getModel().setText("This is a new body");
+      component.refs.titleEditor.getModel().setText("This is a new title");
+
+      component.handleAccept();
+
+      waitsForPromise(() => getScheduler().getNextUpdatePromise());
+
+      runs(() => {
+        expect(component.mode).toBe(Mode.VIEW);
+        expect(pullRequest.body).toBe("This is a new body");
+        expect(pullRequest.title).toBe("This is a new title");
+      });
+    })
 
   });
 

--- a/spec/views/discussion-component-spec.js
+++ b/spec/views/discussion-component-spec.js
@@ -110,9 +110,11 @@ describe("DiscussionComponent", () => {
       component.refs.bodyEditor.getModel().setText("This is a new body");
       component.refs.titleEditor.getModel().setText("This is a new title");
 
+      let promise = getScheduler().getNextUpdatePromise();
+
       component.handleAccept();
 
-      waitsForPromise(() => getScheduler().getNextUpdatePromise());
+      waitsForPromise(() => promise);
 
       runs(() => {
         expect(component.mode).toBe(Mode.VIEW);

--- a/spec/views/discussion-component-spec.js
+++ b/spec/views/discussion-component-spec.js
@@ -119,7 +119,23 @@ describe("DiscussionComponent", () => {
         expect(pullRequest.body).toBe("This is a new body");
         expect(pullRequest.title).toBe("This is a new title");
       });
-    })
+    });
+
+    it("discards changes on cancel", () => {
+      component.refs.bodyEditor.getModel().setText("This is a new body");
+      component.refs.titleEditor.getModel().setText("This is a new title");
+
+      component.handleCancel();
+
+      waitsForPromise(() => getScheduler().getNextUpdatePromise());
+
+      runs(() => {
+        expect(component.mode).toBe(Mode.VIEW);
+
+        expect(pullRequest.body).toBe("This is its body");
+        expect(pullRequest.title).toBe("This is a pull request title");
+      });
+    });
 
   });
 


### PR DESCRIPTION
While the pull request summary is in edit mode, display buttons to accept changes or discard them. When accepted, submit changes to the GitHub API, ensuring that the pull request has not been modified since the last refresh (by tracking the ETag header), and trigger a new refresh.
