### PR TITLE
Rename DiscussionComponent to DetailComponent.

### DIFF
--- a/lib/views/comment-list-component.js
+++ b/lib/views/comment-list-component.js
@@ -1,0 +1,20 @@
+"use babel";
+/** @jsx etch.dom */
+
+import etch from 'etch';
+
+export default class CommentListComponent {
+
+  constructor({pullRequest}) {
+    this.pullRequest = pullRequest;
+
+    etch.createElement(this);
+  }
+
+  render() {
+    return (
+      <ol className="comment-list">
+      </ol>
+    )
+  }
+}

--- a/lib/views/detail-component.js
+++ b/lib/views/detail-component.js
@@ -7,7 +7,7 @@ import {CompositeDisposable} from 'atom';
 import {State} from '../models/pull-request';
 import Mode from '../models/mode';
 
-export default class DiscussionComponent {
+export default class DetailComponent {
 
   constructor({pullRequest}) {
     this.pullRequest = pullRequest;

--- a/lib/views/discussion-component.js
+++ b/lib/views/discussion-component.js
@@ -17,8 +17,8 @@ export default class DiscussionComponent {
   render() {
     return (
       <div className="discussion">
-        {DetailComponent}
-        {CommentListComponent}
+        <DetailComponent pullRequest={this.pullRequest} />
+        <CommentListComponent pullRequest={this.pullRequest} />
       </div>
     )
   }

--- a/lib/views/discussion-component.js
+++ b/lib/views/discussion-component.js
@@ -1,0 +1,25 @@
+"use babel";
+/** @jsx etch.dom */
+
+import etch from 'etch';
+
+import DetailComponent from './detail-component';
+import CommentListComponent from './comment-list-component';
+
+export default class DiscussionComponent {
+
+  constructor({pullRequest}) {
+    this.pullRequest = pullRequest;
+
+    etch.createElement(this);
+  }
+
+  render() {
+    return (
+      <div className="discussion">
+        {DetailComponent}
+        {CommentListComponent}
+      </div>
+    )
+  }
+}

--- a/lib/views/pull-request-component.js
+++ b/lib/views/pull-request-component.js
@@ -3,7 +3,7 @@
 
 import etch from 'etch';
 import TargetComponent from './target-component';
-import DiscussionComponent from './discussion-component';
+import DetailComponent from './detail-component';
 import CommitListComponent from './commit-list-component';
 
 import {loadingPullRequest} from '../models/pull-request';
@@ -13,7 +13,7 @@ export default class PullRequestComponent {
   constructor({repository}) {
     this.repository = repository;
     this.pullRequest = loadingPullRequest;
-    this.activeTab = DiscussionComponent;
+    this.activeTab = DetailComponent;
 
     etch.createElement(this);
 
@@ -41,7 +41,7 @@ export default class PullRequestComponent {
   }
 
   handleDiscussion() {
-    this._chooseTab(DiscussionComponent);
+    this._chooseTab(DetailComponent);
   }
 
   handleCommitList() {
@@ -64,7 +64,7 @@ export default class PullRequestComponent {
     let discussionClasses = "discussion-tab";
     let commitListClasses = "commit-list-tab";
 
-    if (this.activeTab === DiscussionComponent) {
+    if (this.activeTab === DetailComponent) {
       discussionClasses += " selected";
     }
 

--- a/lib/views/pull-request-component.js
+++ b/lib/views/pull-request-component.js
@@ -3,7 +3,7 @@
 
 import etch from 'etch';
 import TargetComponent from './target-component';
-import DetailComponent from './detail-component';
+import DiscussionComponent from './discussion-component';
 import CommitListComponent from './commit-list-component';
 
 import {loadingPullRequest} from '../models/pull-request';
@@ -13,7 +13,7 @@ export default class PullRequestComponent {
   constructor({repository}) {
     this.repository = repository;
     this.pullRequest = loadingPullRequest;
-    this.activeTab = DetailComponent;
+    this.activeTab = DiscussionComponent;
 
     etch.createElement(this);
 
@@ -41,7 +41,7 @@ export default class PullRequestComponent {
   }
 
   handleDiscussion() {
-    this._chooseTab(DetailComponent);
+    this._chooseTab(DiscussionComponent);
   }
 
   handleCommitList() {
@@ -64,7 +64,7 @@ export default class PullRequestComponent {
     let discussionClasses = "discussion-tab";
     let commitListClasses = "commit-list-tab";
 
-    if (this.activeTab === DetailComponent) {
+    if (this.activeTab === DiscussionComponent) {
       discussionClasses += " selected";
     }
 

--- a/spec/views/detail-component-spec.js
+++ b/spec/views/detail-component-spec.js
@@ -127,9 +127,11 @@ describe("DetailComponent", () => {
       component.refs.bodyEditor.getModel().setText("This is a new body");
       component.refs.titleEditor.getModel().setText("This is a new title");
 
+      let promise = getScheduler().getNextUpdatePromise();
+
       component.handleCancel();
 
-      waitsForPromise(() => getScheduler().getNextUpdatePromise());
+      waitsForPromise(() => promise);
 
       runs(() => {
         expect(component.mode).toBe(Mode.VIEW);

--- a/spec/views/detail-component-spec.js
+++ b/spec/views/detail-component-spec.js
@@ -2,14 +2,14 @@
 
 import {getScheduler} from 'etch';
 
-import DiscussionComponent from '../../lib/views/discussion-component';
+import DetailComponent from '../../lib/views/detail-component';
 import PullRequest, {State} from '../../lib/models/pull-request';
 import Repository from '../../lib/models/repository';
 import Mode from '../../lib/models/mode';
 
 import demoTransport from '../../lib/transport/demo';
 
-describe("DiscussionComponent", () => {
+describe("DetailComponent", () => {
   let r;
 
   beforeEach(() => {
@@ -22,7 +22,7 @@ describe("DiscussionComponent", () => {
       let pullRequest = new PullRequest(r);
       pullRequest.state = State.DRAFT;
 
-      let component = new DiscussionComponent({pullRequest});
+      let component = new DetailComponent({pullRequest});
       expect(component.mode).toBe(Mode.EDIT);
     });
 
@@ -30,7 +30,7 @@ describe("DiscussionComponent", () => {
       let pullRequest = new PullRequest(r);
       pullRequest.state = State.OPEN;
 
-      let component = new DiscussionComponent({pullRequest});
+      let component = new DetailComponent({pullRequest});
       expect(component.mode).toBe(Mode.VIEW);
     });
 
@@ -45,7 +45,7 @@ describe("DiscussionComponent", () => {
       pullRequest.body = "This is its body";
       pullRequest.state = State.OPEN;
 
-      component = new DiscussionComponent({pullRequest});
+      component = new DetailComponent({pullRequest});
 
       element = component.element;
     });
@@ -69,7 +69,7 @@ describe("DiscussionComponent", () => {
       pullRequest.body = "This is its body";
       pullRequest.state = State.DRAFT;
 
-      component = new DiscussionComponent({pullRequest});
+      component = new DetailComponent({pullRequest});
 
       element = component.element;
     });


### PR DESCRIPTION
Shuffle components and component names to improve their organization somewhat.

Fixes #9.
